### PR TITLE
remove h1,h2 letter-spacing

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -291,12 +291,10 @@ h1, h2, h3, h4, h5, h6 {
 }
 h1 {
     font-size: 3.6rem;
-    letter-spacing: -2px;
     text-indent: -3px;
 }
 h2 {
     font-size: 3rem;
-    letter-spacing: -1px;
     padding-bottom: 10px;
     border-bottom: 1px solid #EBF2F6;
 }


### PR DESCRIPTION
删除了H1,H2标签的 空格间隔控制。中文字体显示太密。


![screenflow](https://cloud.githubusercontent.com/assets/1088647/20435233/4bebfdda-ade6-11e6-8264-53b78eda44e5.gif)
