### PR TITLE
{{@site.lang}} is deprecated, updated to {{@site.locale}}

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{@site.lang}}">
+<html lang="{{@site.locale}}">
 
 <head>
   {{! Document Settings }}


### PR DESCRIPTION
Reference: https://ghost.org/docs/themes/helpers/site/